### PR TITLE
E2e tests

### DIFF
--- a/e2e/e2e_runner.py
+++ b/e2e/e2e_runner.py
@@ -3,11 +3,12 @@ End-to-end tests for FHIR Nudge proxy using the real client and a live FHIR serv
 
 Usage:
   1. Ensure the Flask proxy is running and FHIR_SERVER_URL is set to a live FHIR server.
-  2. Run this script: python e2e/test_e2e.py
+  2. Run this script: python e2e/e2e_runner.py
   3. The script will exit 0 if all tests pass, nonzero otherwise.
 """
 import sys
 import os
+import requests
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from fhir_nudge.client import FhirNudgeClient
 
@@ -26,30 +27,47 @@ def test_read_patient():
         assert patient["resourceType"] == "Patient"
         assert patient["id"] == TEST_PATIENT_ID
         print("  PASS")
-    except Exception as e:
-        print(f"  FAIL: {e}")
+    except requests.HTTPError as e:
+        print(f"  FAIL: HTTP error: {e}")
         global failures
+        failures += 1
+    except Exception as e:
+        print(f"  FAIL: Unexpected error: {e}")
         failures += 1
 
 def test_read_nonexistent_patient():
     print("Test: Read non-existent Patient...")
     try:
         client.read_resource("Patient", "doesnotexist12345")
-        print("  FAIL: Expected error, got success")
+        print("  FAIL: Expected HTTP 404, got success")
         global failures
         failures += 1
+    except requests.HTTPError as e:
+        if e.response is not None and e.response.status_code == 404:
+            print(f"  PASS (caught expected 404): {e}")
+        else:
+            print(f"  FAIL: Unexpected HTTP error: {e}")
+            failures += 1
     except Exception as e:
-        print(f"  PASS (caught expected error): {e}")
+        print(f"  FAIL: Unexpected error: {e}")
+        failures += 1
 
 def test_read_invalid_resource():
     print("Test: Read invalid resource type...")
     try:
         client.read_resource("NotAType", "123")
-        print("  FAIL: Expected error, got success")
+        print("  FAIL: Expected HTTP 400, got success")
         global failures
         failures += 1
+    except requests.HTTPError as e:
+        if e.response is not None and e.response.status_code == 400:
+            print(f"  PASS (caught expected 400): {e}")
+        else:
+            print(f"  FAIL: Unexpected HTTP error: {e}")
+            failures += 1
     except Exception as e:
-        print(f"  PASS (caught expected error): {e}")
+        print(f"  FAIL: Unexpected error: {e}")
+        failures += 1
 
 if __name__ == "__main__":
     test_read_patient()

--- a/e2e/e2e_runner.py
+++ b/e2e/e2e_runner.py
@@ -14,7 +14,7 @@ from fhir_nudge.client import FhirNudgeClient
 
 # Config: Change as needed for your environment
 PROXY_URL = "http://localhost:8888"  # The running Flask proxy
-TEST_PATIENT_ID = "example"  # Replace with a real Patient ID on your FHIR server
+TEST_PATIENT_ID = "S6426560"  # Replace with a real Patient ID on your FHIR server
 
 client = FhirNudgeClient(PROXY_URL)
 

--- a/e2e/run_e2e.sh
+++ b/e2e/run_e2e.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Fail on error
+set -e
+
+# Set PYTHONPATH to project root for import resolution
+echo "Setting PYTHONPATH to project root..."
+export PYTHONPATH="$(dirname $(dirname $(realpath $0)))"
+
+# Set FHIR_SERVER_URL if not already set
+if [ -z "$FHIR_SERVER_URL" ]; then
+  echo "FHIR_SERVER_URL not set. Using default: http://hapi.fhir.org/baseR4"
+  export FHIR_SERVER_URL="http://hapi.fhir.org/baseR4"
+fi
+
+PROXY_PORT=8888
+PROXY_HOST=localhost
+PROXY_URL="http://$PROXY_HOST:$PROXY_PORT"
+echo "Starting Flask proxy on $PROXY_URL..."
+poetry run flask --app fhir_nudge.app run --host $PROXY_HOST --port $PROXY_PORT &
+PROXY_PID=$!
+
+# Wait for the proxy to be ready (try up to 10 seconds)
+for i in {1..10}; do
+  if curl -s "$PROXY_URL/health" >/dev/null 2>&1 || curl -s "$PROXY_URL" >/dev/null 2>&1; then
+    echo "Flask proxy is up!"
+    break
+  fi
+  sleep 1
+  if [ $i -eq 10 ]; then
+    echo "Flask proxy did not start in time."
+    kill $PROXY_PID
+    exit 1
+  fi
+done
+
+# Run the E2E tests
+echo "Running E2E tests..."
+poetry run python $(dirname $0)/test_e2e.py
+TEST_EXIT_CODE=$?
+
+# Kill the Flask proxy
+kill $PROXY_PID
+wait $PROXY_PID 2>/dev/null
+
+exit $TEST_EXIT_CODE

--- a/e2e/run_e2e.sh
+++ b/e2e/run_e2e.sh
@@ -36,7 +36,7 @@ done
 
 # Run the E2E tests
 echo "Running E2E tests..."
-poetry run python $(dirname $0)/test_e2e.py
+poetry run python $(dirname $0)/e2e_runner.py
 TEST_EXIT_CODE=$?
 
 # Kill the Flask proxy

--- a/e2e/test_e2e.py
+++ b/e2e/test_e2e.py
@@ -1,0 +1,62 @@
+"""
+End-to-end tests for FHIR Nudge proxy using the real client and a live FHIR server.
+
+Usage:
+  1. Ensure the Flask proxy is running and FHIR_SERVER_URL is set to a live FHIR server.
+  2. Run this script: python e2e/test_e2e.py
+  3. The script will exit 0 if all tests pass, nonzero otherwise.
+"""
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from fhir_nudge.client import FhirNudgeClient
+
+# Config: Change as needed for your environment
+PROXY_URL = "http://localhost:8888"  # The running Flask proxy
+TEST_PATIENT_ID = "example"  # Replace with a real Patient ID on your FHIR server
+
+client = FhirNudgeClient(PROXY_URL)
+
+failures = 0
+
+def test_read_patient():
+    print("Test: Read Patient by ID...")
+    try:
+        patient = client.read_resource("Patient", TEST_PATIENT_ID)
+        assert patient["resourceType"] == "Patient"
+        assert patient["id"] == TEST_PATIENT_ID
+        print("  PASS")
+    except Exception as e:
+        print(f"  FAIL: {e}")
+        global failures
+        failures += 1
+
+def test_read_nonexistent_patient():
+    print("Test: Read non-existent Patient...")
+    try:
+        client.read_resource("Patient", "doesnotexist12345")
+        print("  FAIL: Expected error, got success")
+        global failures
+        failures += 1
+    except Exception as e:
+        print(f"  PASS (caught expected error): {e}")
+
+def test_read_invalid_resource():
+    print("Test: Read invalid resource type...")
+    try:
+        client.read_resource("NotAType", "123")
+        print("  FAIL: Expected error, got success")
+        global failures
+        failures += 1
+    except Exception as e:
+        print(f"  PASS (caught expected error): {e}")
+
+if __name__ == "__main__":
+    test_read_patient()
+    test_read_nonexistent_patient()
+    test_read_invalid_resource()
+    if failures:
+        print(f"\n{failures} test(s) failed.")
+        sys.exit(1)
+    print("\nAll E2E tests passed!")
+    sys.exit(0)

--- a/fhir_nudge/app.py
+++ b/fhir_nudge/app.py
@@ -47,11 +47,12 @@ def load_capability_statement():
         sys.exit(1)
 
 def filter_headers(headers):
+    # Normalize header keys to lower-case for case-insensitive filtering
     excluded = {
-        'Transfer-Encoding', 'Content-Encoding', 'Content-Length', 'Connection',
-        'Keep-Alive', 'Proxy-Authenticate', 'Proxy-Authorization', 'TE', 'Trailer', 'Upgrade'
+        'transfer-encoding', 'content-encoding', 'content-length', 'connection',
+        'keep-alive', 'proxy-authenticate', 'proxy-authorization', 'te', 'trailer', 'upgrade'
     }
-    return {k: v for k, v in headers.items() if k not in excluded}
+    return {k: v for k, v in headers.items() if k.lower() not in excluded}
 
 capability_index = None
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -66,3 +66,62 @@ def test_read_resource_not_found(client, patch_fhir_requests):
     patch_fhir_requests.side_effect = resource_side_effect
     resp = client.get('/readResource/Patient/doesnotexist')
     assert resp.status_code == 404 or resp.status_code == 200  # Depending on proxy behavior
+
+def test_read_resource_fhir_plaintext_error(client, patch_fhir_requests):
+    original_side_effect = patch_fhir_requests.side_effect
+    def resource_side_effect(url, *args, **kwargs):
+        if url.endswith("/metadata"):
+            return original_side_effect(url)
+        class MockResourceResp:
+            status_code = 500
+            content = b'Server error occurred'
+            headers = {"Content-Type": "text/plain"}
+            def raise_for_status(self): pass
+            def json(self): raise ValueError("Not JSON")
+            @property
+            def text(self): return self.content.decode()
+        return MockResourceResp()
+    patch_fhir_requests.side_effect = resource_side_effect
+    resp = client.get('/readResource/Patient/123')
+    assert resp.status_code == 500
+    assert "error" in resp.json
+    assert "Server error occurred" in resp.json["error"]
+
+def test_read_resource_fhir_custom_json_error(client, patch_fhir_requests):
+    original_side_effect = patch_fhir_requests.side_effect
+    def resource_side_effect(url, *args, **kwargs):
+        if url.endswith("/metadata"):
+            return original_side_effect(url)
+        class MockResourceResp:
+            status_code = 403
+            content = b'{"message": "Forbidden"}'
+            headers = {"Content-Type": "application/json"}
+            def raise_for_status(self): pass
+            def json(self): return {"message": "Forbidden"}
+            @property
+            def text(self): return self.content.decode()
+        return MockResourceResp()
+    patch_fhir_requests.side_effect = resource_side_effect
+    resp = client.get('/readResource/Patient/123')
+    assert resp.status_code == 403
+    assert resp.json["message"] == "Forbidden"
+
+def test_read_resource_fhir_empty_error(client, patch_fhir_requests):
+    original_side_effect = patch_fhir_requests.side_effect
+    def resource_side_effect(url, *args, **kwargs):
+        if url.endswith("/metadata"):
+            return original_side_effect(url)
+        class MockResourceResp:
+            status_code = 404
+            content = b''
+            headers = {"Content-Type": "application/fhir+json"}
+            def raise_for_status(self): pass
+            def json(self): raise ValueError("No content")
+            @property
+            def text(self): return ""
+        return MockResourceResp()
+    patch_fhir_requests.side_effect = resource_side_effect
+    resp = client.get('/readResource/Patient/doesnotexist')
+    assert resp.status_code == 404
+    assert "error" in resp.json
+    assert "FHIR server returned status 404" in resp.json["error"]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -62,6 +62,9 @@ def test_read_resource_not_found(client, patch_fhir_requests):
             def raise_for_status(self): pass
             def json(self):
                 return {"resourceType": "OperationOutcome", "issue": [{"severity": "error", "code": "not-found"}]}
+            @property
+            def text(self):
+                return self.content.decode()
         return MockResourceResp()
     patch_fhir_requests.side_effect = resource_side_effect
     resp = client.get('/readResource/Patient/doesnotexist')


### PR DESCRIPTION
This pull request introduces end-to-end (E2E) testing for the FHIR Nudge proxy, with a focus on ensuring the proxy's reliability and correctness when interacting with a live FHIR server. The changes include the addition of a new E2E test script, a shell script to run the tests, and improvements to the proxy's request handling.

End-to-end testing:

* [`e2e/e2e_runner.py`](diffhunk://#diff-1f6347603c0774563c091e9d19970730b8c293b83834714a94c093a8ff29539cR1-R80): Added a new script to perform E2E tests on the FHIR Nudge proxy, including tests for reading a patient by ID, reading a non-existent patient, and reading an invalid resource type.
* [`e2e/run_e2e.sh`](diffhunk://#diff-636671240ccc15e69a87a926351adeb6aa53b7cbf003db90e7a46881e426c8d0R1-R46): Added a shell script to automate the setup and execution of the E2E tests, including starting the Flask proxy and setting environment variables.

Proxy request handling improvements:

* [`fhir_nudge/app.py`](diffhunk://#diff-649bd5acee93a7728b8d9db1ceec86dd8c3de31475f6613891860298e8219740R49-R55): Added a `filter_headers` function to exclude certain headers when forwarding requests to the FHIR server, and updated the `read_resource` function to use this filtered set of headers. [[1]](diffhunk://#diff-649bd5acee93a7728b8d9db1ceec86dd8c3de31475f6613891860298e8219740R49-R55) [[2]](diffhunk://#diff-649bd5acee93a7728b8d9db1ceec86dd8c3de31475f6613891860298e8219740L80-R91)